### PR TITLE
fix: share dropdown menu item styling

### DIFF
--- a/src/components/base/Dropdown.astro
+++ b/src/components/base/Dropdown.astro
@@ -136,7 +136,7 @@ const {
     max-inline-size: calc(100vw - 1.25rem);
     max-block-size: min(24rem, calc(100vh - 6rem));
     overflow: auto;
-    padding-block: var(--space-3xs);
+    padding-block: 0;
     border: 1px solid var(--border);
     border-radius: var(--radius-md);
     background: var(--background);
@@ -175,16 +175,60 @@ const {
   }
 
   [data-dropdown-item] {
-    display: block;
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
     inline-size: 100%;
+    min-block-size: 44px;
+    margin: 0;
+    padding: var(--space-2xs) var(--space-xs);
+    border: 1px solid transparent;
+    appearance: none;
+    background: transparent;
+    color: var(--foreground);
+    font: inherit;
+    text-align: start;
+    text-decoration: none;
+    white-space: nowrap;
+    cursor: pointer;
     transition:
       background-color var(--motion-duration) var(--motion-ease),
+      border-color var(--motion-duration) var(--motion-ease),
       color var(--motion-duration-fast) var(--motion-ease);
+  }
+
+  [data-dropdown-item]:first-child {
+    border-start-start-radius: calc(var(--radius-md) - 1px);
+    border-start-end-radius: calc(var(--radius-md) - 1px);
+  }
+
+  [data-dropdown-item]:last-child {
+    border-end-start-radius: calc(var(--radius-md) - 1px);
+    border-end-end-radius: calc(var(--radius-md) - 1px);
   }
 
   @media (hover: hover) and (pointer: fine) {
     [data-dropdown-item]:hover {
-      background: var(--muted);
+      border-color: color-mix(in oklab, var(--accent) 55%, var(--border));
+      background-color: color-mix(in oklab, var(--accent) 24%, transparent);
+      color: var(--foreground);
+    }
+  }
+
+  [data-dropdown-item][aria-current],
+  [data-dropdown-item][aria-selected="true"],
+  [data-dropdown-item][data-active] {
+    background-color: var(--primary);
+    color: var(--primary-foreground);
+    font-weight: var(--font-weight-medium);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    [data-dropdown-item][aria-current]:hover,
+    [data-dropdown-item][aria-selected="true"]:hover,
+    [data-dropdown-item][data-active]:hover {
+      background-color: color-mix(in oklab, var(--primary) 88%, var(--accent));
+      color: var(--primary-foreground);
     }
   }
 </style>

--- a/src/components/layout/MobileMenu.astro
+++ b/src/components/layout/MobileMenu.astro
@@ -79,55 +79,8 @@ import Icon from "@/components/base/Icon.astro"
   }
 
   :global(.mobile-menu-content) {
-    padding-block: 0;
-
     @media (width >= 40rem) {
       display: none;
     }
-  }
-
-  a[data-dropdown-item] {
-    display: flex;
-    align-items: center;
-    box-sizing: border-box;
-    min-block-size: 44px;
-    inline-size: 100%;
-    padding: var(--space-2xs) var(--space-xs);
-    border: 1px solid transparent;
-
-    color: var(--foreground);
-    text-decoration: none;
-    white-space: nowrap;
-    transition:
-      background-color var(--motion-duration) var(--motion-ease),
-      border-color var(--motion-duration) var(--motion-ease),
-      color var(--motion-duration-fast) var(--motion-ease);
-  }
-
-  a[data-dropdown-item]:first-child {
-    border-start-start-radius: calc(var(--radius-md) - 1px);
-    border-start-end-radius: calc(var(--radius-md) - 1px);
-  }
-
-  a[data-dropdown-item]:last-child {
-    border-end-start-radius: calc(var(--radius-md) - 1px);
-    border-end-end-radius: calc(var(--radius-md) - 1px);
-  }
-
-  a[data-dropdown-item]:hover {
-    border-color: color-mix(in oklab, var(--accent) 55%, var(--border));
-    background-color: color-mix(in oklab, var(--accent) 24%, transparent);
-    color: var(--foreground);
-  }
-
-  a[data-dropdown-item][aria-current] {
-    background-color: var(--primary);
-    color: var(--primary-foreground);
-    font-weight: var(--font-weight-medium);
-  }
-
-  a[data-dropdown-item][aria-current]:hover {
-    background-color: color-mix(in oklab, var(--primary) 88%, var(--accent));
-    color: var(--primary-foreground);
   }
 </style>

--- a/src/components/layout/ThemeToggle.astro
+++ b/src/components/layout/ThemeToggle.astro
@@ -62,32 +62,7 @@ import Icon from "@/components/base/Icon.astro"
   }
 
   button[data-dropdown-item] {
-    display: flex;
-    align-items: center;
     gap: 0.5rem;
-    width: 100%;
-    min-height: 2.75rem; /* 44px */
-    padding: 0.5rem 0.75rem;
-    border-radius: 0.375rem;
-    border: 1px solid transparent;
-    white-space: nowrap;
-    transition:
-      background-color var(--motion-duration) var(--motion-ease),
-      color var(--motion-duration-fast) var(--motion-ease);
-  }
-  @media (hover: hover) and (pointer: fine) {
-    button[data-dropdown-item]:hover {
-      background-color: color-mix(in oklch, var(--accent) 50%, transparent);
-    }
-  }
-  button[data-dropdown-item][data-active] {
-    background-color: color-mix(in oklch, var(--primary) 80%, transparent);
-    color: var(--primary-foreground);
-    font-weight: 500;
-  }
-
-  .theme-menu {
-    background: var(--background);
   }
 
   :global(.theme-no-transition *),


### PR DESCRIPTION
## Summary
- Move shared dropdown item sizing, padding, border, radius, hover, and active-state styles into the base Dropdown component.
- Remove duplicated dropdown item styling from ThemeToggle and MobileMenu so they share the same UI behavior.

## Validation
- pnpm exec biome format --write src/components/base/Dropdown.astro src/components/layout/ThemeToggle.astro src/components/layout/MobileMenu.astro
- pnpm exec astro check
- pnpm lint
- pnpm build
