### PR TITLE
Refresh portfolio projects and reusable UI polish

### DIFF
--- a/src/components/base/Link.astro
+++ b/src/components/base/Link.astro
@@ -50,8 +50,7 @@ const relValue = relTokens.length > 0 ? relTokens.join(" ") : undefined
     color: inherit;
     transition:
       color var(--motion-duration-fast) var(--motion-ease),
-      text-decoration-color var(--motion-duration) var(--motion-ease),
-      background-size var(--motion-duration) var(--motion-ease);
+      text-decoration-color var(--motion-duration) var(--motion-ease);
   }
 
   @media (hover: hover) and (pointer: fine) {
@@ -60,10 +59,14 @@ const relValue = relTokens.length > 0 ? relTokens.join(" ") : undefined
     }
   }
 
-  /* Opting in here (rather than on every [data-link]) keeps the wipe off the
-     button- and badge-shaped anchors that also render through this component. */
+  /* Opting in here keeps underlines off button- and badge-shaped links. A
+     native text decoration wraps cleanly and only needs a color transition. */
   [data-link][data-underline] {
     --underline: var(--muted-foreground);
-    --underline-wipe: currentColor;
+    text-decoration-skip-ink: auto;
+  }
+
+  [data-link][data-underline]:is(:hover, :focus-visible) {
+    text-decoration-color: currentColor;
   }
 </style>

--- a/src/components/layout/Section.astro
+++ b/src/components/layout/Section.astro
@@ -22,10 +22,10 @@ const {
   <section-heading>
     <h2 id={title.toLowerCase()}>{title}</h2>
     {moreLink && (
-      <Link href={moreLink} underline class="section-more">
-        {moreText}
-      </Link>
-    )}
+        <Link href={moreLink} underline class="section-more">
+          {moreText}
+        </Link>
+      )}
   </section-heading>
   <slot />
 </section>
@@ -35,7 +35,7 @@ const {
     display: flex;
     flex-direction: column;
     gap: var(--space-s);
-    margin-block-start: var(--space-xl);
+    margin-block-start: var(--space-l);
   }
 
   .section-block[data-spacing="none"] {
@@ -118,7 +118,7 @@ const {
 
   @media (width < 40rem) {
     .section-block {
-      margin-block-start: var(--space-l);
+      margin-block-start: var(--space-m);
     }
 
     section-heading {

--- a/src/components/projects/ProjectRow.astro
+++ b/src/components/projects/ProjectRow.astro
@@ -11,8 +11,7 @@ interface Props {
 }
 
 const { project } = Astro.props
-const { title, isHighlighted, code, doc, paper, url, release, skills } =
-  project.data
+const { title, selected, code, doc, paper, url, release, skills } = project.data
 
 const links = getProjectLinks(code, doc, paper, url, release)
 
@@ -24,12 +23,12 @@ const titleHref = hasDetailPage ? `/projects/${project.id}` : primaryLink?.href
 ---
 
 <article
-  class:list={["project-row", { "is-highlighted": isHighlighted }]}
+  class:list={["project-row", { "is-highlighted": selected }]}
   data-project-skills={skills.map((skill) => slugify(skill)).join(",")}
 >
   <div class="project-row-head">
     <h3 class="project-row-title">
-      {isHighlighted && <span class="sr-only">Featured project: </span>}
+      {selected && <span class="sr-only">Featured project: </span>}
       {titleHref ? (
           <Link href={titleHref} underline>
             {title}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -74,7 +74,6 @@ const projects = defineCollection({
   schema: z
     .object({
       title: z.string().max(75),
-      isHighlighted: z.boolean().default(false),
       selected: z.boolean().default(false),
       fromDate: yearMonthDateSchema.optional(),
       toDate: yearMonthDateSchema.optional(),

--- a/src/content/about.md
+++ b/src/content/about.md
@@ -7,6 +7,6 @@ I research **current and future AI that empowers human plurality and broader wor
 
 My technical work focuses on data and [evaluation](https://aimslab.stanford.edu/textbook/), to make grounded, predictive, specific claims about AI capability and safety, then improve them.
 
-I'm interning at [Lida Safety Research](https://www.lidasafety.org/). I also contribute to community research at various capacities, including Cohere Labs Community (leadership & analysis), [MatrAIx](https://matraix.ai/) (AI simulation apps), and [BenchFlow](https://www.benchflow.ai/) (evaluation infrastructure). Recently I worked on [SEATauBench](https://seacrowd.org/apprentice-projects/2026/multilingual-agentic-underrepresented), and [CoT monitoring behavior](/projects/2025-cot-monitoring).
+I'm interning at [Lida Safety Research](https://www.lidasafety.org/). I also contribute to community research at various capacities, including Cohere Labs Community (leadership & analysis), and [BenchFlow](https://www.benchflow.ai/) (evaluation infrastructure). Recently I worked on [SEATauBench](https://seacrowd.org/apprentice-projects/2026/multilingual-agentic-underrepresented), and [CoT monitoring behavior](/projects/2025-cot-monitoring).
 
 I am **seeking SWE & AI Engineer roles** (Vietnam/Remote) and **research-oriented Master's in CS, AI, or NLP for Fall 2027**. Open to research collaborations.

--- a/src/content/experience.json
+++ b/src/content/experience.json
@@ -7,18 +7,18 @@
     "orgUrl": "https://www.lidasafety.org/",
     "startDate": "2026-07",
     "location": "Remote",
-    "description": "Mentored by Dr. Linh Le and Dr. David Williams-King."
+    "description": "CastBench, an AI governance benchmark. Mentored by Dr. Linh Le and Dr. David Williams-King."
   },
   {
     "id": "seacrowd-2026",
     "category": "research",
     "title": "AI Research Mentee",
-    "org": "SEACrowd, SEACrowd Apprentice Research Program 2026",
+    "org": "SEACrowd, Apprentice Research Program 2026",
     "orgUrl": "https://seacrowd.org/apprentice-projects/2026/multilingual-agentic-underrepresented",
     "startDate": "2026-02",
     "endDate": "2026-06",
     "location": "Remote",
-    "description": "Extended Tau2-Bench into SEATauBench across five Southeast Asian languages, localizing executable agent-user-tool tasks and analyzing multi-turn trajectory failures."
+    "description": "SEATauBench: Stress-testing Tau2-Bench, a conversational user-agent-tool benchmark, in progressive localization across five Southeast Asian languages."
   },
   {
     "id": "algoverse-2025",

--- a/src/content/projects/2023-bayesian-modeling.md
+++ b/src/content/projects/2023-bayesian-modeling.md
@@ -2,7 +2,7 @@
 title: "Bayesian Hierarchical Modeling for GP Visit Count Data"
 description: "Analyze GP visit patterns using Zero-Inflated Poisson models with complete and partial pooling, with Bayesian inference and data imputation."
 toDate: 2023-11-28
-isHighlighted: false
+selected: false
 code: https://github.com/mychiffonn/jupyter-notebooks/blob/main/CS146-project-2.ipynb
 types:
   - research

--- a/src/content/projects/2024-minillama.md
+++ b/src/content/projects/2024-minillama.md
@@ -10,7 +10,7 @@ skills:
   - Python
   - PyTorch
   - Model training
-isHighlighted: true
+selected: true
 ---
 
 I implemented a minimalist Llama-2 language model from scratch in PyTorch, including self-attention, Rotary Positional Embeddings (RoPE), RMSNorm, SwiGLU activation functions, and core transformer blocks.

--- a/src/content/projects/2025-astro-scholar-theme.md
+++ b/src/content/projects/2025-astro-scholar-theme.md
@@ -1,9 +1,11 @@
 ---
-title: Astro Scholar Theme for Academics
-description: Created and maintain a personal academic Astro theme for research portfolios, publications, projects, and blogs.
+title: MyScholar, Astro Theme for Academics
+description: Created and maintain a personal (or group) academic Astro theme for research portfolios, publications, projects, and blogs.
 fromDate: 2025-06
-code: https://github.com/mychiffonn/astro-scholar
-url: https://mychiffonn.com/
+selected: true
+code: https://github.com/mychiffonn/myscholar
+doc: https://astro.build/themes/details/astro-star-scholar/
+url: https://astro-scholar.pages.dev/
 types:
   - tool
   - open-source

--- a/src/content/projects/2025-cot-monitoring.md
+++ b/src/content/projects/2025-cot-monitoring.md
@@ -1,7 +1,7 @@
 ---
 title: Behavior of Chain-of-thought Monitorability
 fromDate: 2025-10-05
-isHighlighted: true
+selected: true
 description: Studying how monitor effectiveness changes as the capability gap between monitor and target models widens, with a case study on distinguishing sandbagging from genuine incapability.
 code: https://github.com/yoenoo/algoverse_nacm
 types:

--- a/src/content/projects/2025-sportconnect.md
+++ b/src/content/projects/2025-sportconnect.md
@@ -6,7 +6,6 @@ doc: https://github.com/mychiffonn/sport-connect/blob/main/README.md
 url: https://sport-connect-ccmg.onrender.com/
 fromDate: 2025-11-10
 toDate: 2025-11-19
-isHighlighted: true
 types:
   - product
 skills:

--- a/src/content/projects/2026-benchflow.md
+++ b/src/content/projects/2026-benchflow.md
@@ -2,7 +2,7 @@
 title: BenchFlow (Open Source)
 description: Contributed to RL runtime environments and community-based AI benchmarks.
 fromDate: 2026-04
-isHighlighted: true
+selected: true
 code: https://github.com/benchflow-ai/benchflow
 url: https://benchflow.ai/
 types:

--- a/src/content/projects/2026-futurekind-animals-agentic-ai.md
+++ b/src/content/projects/2026-futurekind-animals-agentic-ai.md
@@ -3,7 +3,6 @@ title: Animals-Aligned Agentic AI Benchmarking
 description: Evaluated whether implicit values in agentic LLMs are inclusive of animals, by extending CaML's The Animal Compassion
 fromDate: 2026-04
 toDate: 2026-07
-selected: true
 doc: https://docs.google.com/document/d/1LoJAJvjseK2JcR-zi1t63eVeXS3_nZcaie-kXhn6_fo/edit?usp=sharing
 types:
   - research

--- a/src/content/projects/2026-multicultural-riddles-benchmarking.md
+++ b/src/content/projects/2026-multicultural-riddles-benchmarking.md
@@ -3,6 +3,8 @@ title: Multicultural Riddles Benchmarking
 description: Analysis of LLM factuality, hallucination, topic patterns, and cross-cultural reasoning failures on multicultural riddles.
 fromDate: 2026-04
 selected: true
+code: https://github.com/Cohere-Labs-Community/RiddlesBenchmarking
+doc: https://docs.google.com/document/d/1-14ku3mfooGmgpsiNnHzXeOmeXWKq-CA/edit
 types:
   - research
 skills:

--- a/src/content/projects/2026-multilingual-sae.md
+++ b/src/content/projects/2026-multilingual-sae.md
@@ -3,7 +3,6 @@ title: Multilingual Representations with Sparse Autoencoders
 description: Investigated multilingual LLM representations with SAEs and feature steering across 67 languages.
 fromDate: 2026-03
 toDate: 2026-03
-selected: true
 code: https://github.com/mychiffonn/inside-tiny-aya
 url: https://huggingface.co/Farseen0/tiny-aya-saes
 types:

--- a/src/content/projects/2026-seataubench.md
+++ b/src/content/projects/2026-seataubench.md
@@ -3,7 +3,7 @@ title: SEATauBench
 description: Extended Tau2-Bench for low-resource Southeast Asian languages and localized agentic evaluation.
 fromDate: 2026-02
 toDate: 2026-06
-isHighlighted: true
+selected: true
 code: https://github.com/sierra-research/tau2-bench
 paper: https://arxiv.org/abs/2606.28715
 url: https://seacrowd.org/apprentice-projects/2026/multilingual-agentic-underrepresented

--- a/src/content/projects/README.md
+++ b/src/content/projects/README.md
@@ -34,7 +34,6 @@ types:
   - "coursework"
 skills:
   - "R"
-isHighlighted: true
 selected: true
 release: "https://github.com/username/synthetic-control/releases/tag/v1.0.0"
 ---
@@ -42,27 +41,26 @@ release: "https://github.com/username/synthetic-control/releases/tag/v1.0.0"
 
 ## Fields
 
-| Key | Type | Required? | Description | Notes |
-| --- | --- | --- | --- | --- |
-| `title` | String | ✅ | The title of the project |  |
-| `description` | String | ❌ | Brief project description (max 100 characters) | Used in project cards; falls back to content |
-| `fromDate` | Date | ❌ | Start date of the project | YYYY-MM or YYYY-MM-DD format |
-| `toDate` | Date | ❌ | End date of the project | YYYY-MM or YYYY-MM-DD format. Must be ≥ fromDate |
-| `code` | URL | ❌ | Link to source code repository | Must be a valid URL |
-| `doc` | URL | ❌ | Link to project documentation | Must be a valid URL |
-| `paper` | URL | ❌ | Link to a paper or preprint | Must be a valid URL |
-| `url` | URL | ❌ | Link to live site or demo | Must be a valid URL |
-| `types` | Enum[] | ❌ | Any of: `research`, `product`, `tool`, `open-source`, `coursework` | Describes what the project is; filterable on the projects page |
-| `skills` | String[] | ❌ | Free-form skills and technologies used by the project | Filterable on the projects page; unique values are aggregated into the Tech Stack section |
-| `isHighlighted` | Boolean | ❌ | Whether to feature this project | Defaults to `false` |
-| `selected` | Boolean | ❌ | Whether this project is a substantial/research-relevant selected project | Defaults to `false` |
-| `release` | URL | ❌ | Link to release or deployment | Must be a valid URL |
+| Key           | Type     | Required? | Description                                                              | Notes                                                                                     |
+| ------------- | -------- | --------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `title`       | String   | ✅        | The title of the project                                                 |                                                                                           |
+| `description` | String   | ❌        | Brief project description (max 100 characters)                           | Used in project cards; falls back to content                                              |
+| `fromDate`    | Date     | ❌        | Start date of the project                                                | YYYY-MM or YYYY-MM-DD format                                                              |
+| `toDate`      | Date     | ❌        | End date of the project                                                  | YYYY-MM or YYYY-MM-DD format. Must be ≥ fromDate                                          |
+| `code`        | URL      | ❌        | Link to source code repository                                           | Must be a valid URL                                                                       |
+| `doc`         | URL      | ❌        | Link to project documentation                                            | Must be a valid URL                                                                       |
+| `paper`       | URL      | ❌        | Link to a paper or preprint                                              | Must be a valid URL                                                                       |
+| `url`         | URL      | ❌        | Link to live site or demo                                                | Must be a valid URL                                                                       |
+| `types`       | Enum[]   | ❌        | Any of: `research`, `product`, `tool`, `open-source`, `coursework`       | Describes what the project is; filterable on the projects page                            |
+| `skills`      | String[] | ❌        | Free-form skills and technologies used by the project                    | Filterable on the projects page; unique values are aggregated into the Tech Stack section |
+| `selected`    | Boolean  | ❌        | Whether to feature this project                                          | Defaults to `false`                                                                       |
+| `release`     | URL      | ❌        | Link to release or deployment                                            | Must be a valid URL                                                                       |
 
 ## Notes
 
 - `README.md` will be ignored by the content loader
 - To modify the schema, see the `projects` collection in [src/content.config.ts](../../src/content.config.ts)
-- Projects are sorted by `isHighlighted` (true > false) `toDate` (descending), then `fromDate` (descending), then `title` (ascending)
+- Projects are sorted by `selected` (true > false) `toDate` (descending), then `fromDate` (descending), then `title` (ascending)
 - Project cards show `description` if available, otherwise truncated content with a "read more" link
 - External links use the LinkExternal component and include hover effects
 - The entire project card is clickable and navigates to the project detail page

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -70,8 +70,8 @@ export function getProjectSkillCounts(projects: Project[], minimum = 2) {
 function sortProjects(projects: Project[]): Project[] {
   return projects.sort((a, b) => {
     // First, prioritize highlighted projects
-    if (a.data.isHighlighted && !b.data.isHighlighted) return -1
-    if (!a.data.isHighlighted && b.data.isHighlighted) return 1
+    if (a.data.selected && !b.data.selected) return -1
+    if (!a.data.selected && b.data.selected) return 1
 
     // Then sort by end date (most recent first); ongoing projects rank highest.
     const ongoingSentinel = new Date(8640000000000000)

--- a/src/pages/projects/[...id].astro
+++ b/src/pages/projects/[...id].astro
@@ -39,7 +39,7 @@ const [{ Content }, navigation] = await Promise.all([
 ])
 const {
   title,
-  isHighlighted,
+  selected,
   fromDate,
   toDate,
   code,
@@ -73,7 +73,7 @@ const rawMarkdown = project.body
   <header class="project-header">
     <div class="project-title-row">
       <h1>{title}</h1>
-      {isHighlighted && (
+      {selected && (
           <Badge variant="default" class="featured-badge">
             <Icon name="star" class="featured-badge-icon" />
             Featured

--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -19,6 +19,38 @@
   transition-timing-function: var(--motion-ease);
 }
 
+[data-slot="card"]::before {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  padding: 1px;
+  border-radius: inherit;
+  background:
+    linear-gradient(
+      110deg,
+      transparent 20%,
+      color-mix(in oklab, var(--primary) 82%, transparent) 40%,
+      color-mix(in oklab, var(--accent) 88%, transparent) 50%,
+      color-mix(in oklab, var(--primary) 82%, transparent) 60%,
+      transparent 80%
+    )
+    100% 0 / 300% 100%;
+  content: "";
+  opacity: 0;
+  pointer-events: none;
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  transition-property: opacity;
+  transition-duration: var(--motion-duration-fast);
+  transition-timing-function: var(--motion-ease);
+}
+
 [data-slot="card"][data-orientation="stacked"] {
   flex-direction: column;
 }
@@ -224,6 +256,11 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
+  [data-slot="card"]:hover::before {
+    opacity: 1;
+    animation: card-border-flow 2.4s linear infinite;
+  }
+
   [data-slot="card"]:hover {
     border-color: color-mix(in oklab, var(--border) 82%, transparent);
   }
@@ -241,9 +278,25 @@
   }
 }
 
+@keyframes card-border-flow {
+  from {
+    background-position: 100% 0;
+  }
+
+  to {
+    background-position: -50% 0;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   [data-slot="card"],
+  [data-slot="card"]::before,
   [data-slot="card-title"] {
     transition-duration: 0.01ms;
+  }
+
+  [data-slot="card"]:hover::before {
+    animation: none;
+    background-position: 50% 0;
   }
 }


### PR DESCRIPTION
## What changed

- consolidate featured-project metadata on the existing `selected` field
- refresh portfolio experience and project details
- use native wrapping link underlines and tighter section spacing
- add an animated card-border treatment with reduced-motion fallback

## Why

The local site changes had accumulated across project metadata, portfolio content, and reusable UI polish. This packages them on a fresh branch from `origin/main` while keeping the project schema and rendering paths consistent.

## Impact

Projects now use one feature-selection flag throughout sorting and rendering. Updated portfolio details are published, and shared interactive treatments are more compact and robust across wrapped links, hover states, and reduced-motion preferences.

## Validation

- `pnpm format:check`
- `pnpm lint` (passes with existing type-resolution warnings)
- `pnpm lint:styles`
- `pnpm astro check`
- `pnpm build`
- desktop and mobile visual checks in light and dark modes

`pnpm test:markdown` is not available in this repository's current `package.json`.

## Related

- Reusable theme transition: [mychiffonn/myscholar#1](https://github.com/mychiffonn/myscholar/pull/1)
